### PR TITLE
Fix: corrects h-card logo class

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -23,7 +23,7 @@
       <div class="container">
         <div class="row">
           <div class="col-sm-12 col-md-3">
-            <a class="u-url" href="https://microformats.io/"><img alt="Microformats logo" class="u-photo" src="/assets/images/microformats-logo.svg" /></a>
+            <a class="u-url" href="https://microformats.io/"><img alt="Microformats logo" class="u-logo" src="/assets/images/microformats-logo.svg" /></a>
           </div>
 
           <div class="col-md-9 col-sm-12">


### PR DESCRIPTION
u-photo is a for a photo of the person/organization. The image on the site is the microformats logo, so the correct classname is u-logo.