### PR TITLE
Fix: adds height and width attributes

### DIFF
--- a/public/assets/images/microformats-logo.svg
+++ b/public/assets/images/microformats-logo.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 316 307">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 316 307" width="316" height="307">
     <title>Microformats</title>
     <linearGradient id="bottom" y2="1">
         <stop offset="0" stop-color="#6ba140"/>


### PR DESCRIPTION
There are strange rendering issues with svg files in `<img>` elements when the svg element is missing `height` and `width` attributes.