### PR TITLE
Fix: corrects alt attributes

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -21,7 +21,7 @@
       <div class="container">
         <div class="row">
           <div class="col-sm-12 col-md-3">
-            <a class="u-url" href="https://microformats.io/"><img alt="Microformats logo" class="u-logo" src="/assets/images/microformats-logo.svg" /></a>
+            <a class="u-url" href="https://microformats.io/"><img alt="Microformats" class="u-logo" src="/assets/images/microformats-logo.svg" /></a>
           </div>
 
           <div class="col-md-9 col-sm-12">
@@ -180,17 +180,17 @@
         <div class="row">
           <div class="col-3">
             <a target="blank" href="https://mastodon.social/about">
-              <img alt="Mastodon logo" src="/assets/images/examples/mastodon.png" />
+              <img alt="Mastodon" src="/assets/images/examples/mastodon.png" />
             </a>
           </div>
           <div class="col-6">
             <a target="blank" href="https://indieweb.org">
-              <img alt="Indie Web Camp logo" src="/assets/images/examples/indie-web-camp.png" />
+              <img alt="IndieWebCamp" src="/assets/images/examples/indie-web-camp.png" />
             </a>
           </div>
           <div class="col-3">
             <a target="blank" href="https://micro.blog">
-              <img alt="micro.blog logo" src="/assets/images/examples/micro-blog.png" />
+              <img alt="micro.blog" src="/assets/images/examples/micro-blog.png" />
             </a>
           </div>
         </div>
@@ -248,27 +248,27 @@
           <div class="col-4 col-sm-2 offset-sm-1 language language-go">
             <a class="btn btn-secondary btn-sm" href="https://go.microformats.io">Website</a>
             <a class="btn btn-secondary btn-sm" href="https://github.com/willnorris/microformats">Library</a>
-            <a href="https://go.microformats.io"><img alt="Go logo" src="/assets/images/parsers/go.png" /></a>
+            <a href="https://go.microformats.io"><img alt="Go" src="/assets/images/parsers/go.png" /></a>
           </div>
           <div class="col-4 col-sm-2 language language-node">
             <a class="btn btn-secondary btn-sm" href="http://node.microformats.io">Website</a>
             <a class="btn btn-secondary btn-sm" href="https://github.com/glennjones/microformat-node">Library</a>
-            <a href="http://node.microformats.io"><img alt="Node logo" src="/assets/images/parsers/node.svg" /></a>
+            <a href="http://node.microformats.io"><img alt="Node" src="/assets/images/parsers/node.svg" /></a>
           </div>
           <div class="col-4 col-sm-2 language language-php">
             <a class="btn btn-secondary btn-sm" href="https://php.microformats.io">Website</a>
             <a class="btn btn-secondary btn-sm" href="https://github.com/indieweb/php-mf2">Library</a>
-            <a href="https://php.microformats.io"><img alt="php logo" src="/assets/images/parsers/php.svg" /></a>
+            <a href="https://php.microformats.io"><img alt="php" src="/assets/images/parsers/php.svg" /></a>
           </div>
           <div class="col-4 col-sm-2 offset-2 offset-sm-0 language language-python">
             <a class="btn btn-secondary btn-sm" href="https://python.microformats.io">Website</a>
             <a class="btn btn-secondary btn-sm" href="https://github.com/tommorris/mf2py">Library</a>
-            <a href="https://python.microformats.io"><img alt="Python logo" src="/assets/images/parsers/python.svg" /></a>
+            <a href="https://python.microformats.io"><img alt="Python" src="/assets/images/parsers/python.svg" /></a>
           </div>
           <div class="col-4 col-sm-2 language language-ruby">
             <a class="btn btn-secondary btn-sm" href="https://ruby.microformats.io">Website</a>
             <a class="btn btn-secondary btn-sm" href="https://github.com/indieweb/microformats-ruby">Library</a>
-            <a href="https://ruby.microformats.io"><img alt="Ruby logo" src="/assets/images/parsers/ruby.svg" /></a>
+            <a href="https://ruby.microformats.io"><img alt="Ruby" src="/assets/images/parsers/ruby.svg" /></a>
           </div>
         </div>
 


### PR DESCRIPTION
Removes 'logo' from alt attributes in img elements, because the alt attribute should be a replacement
for the image, not a description of it.

Fixes #53. Obviates #54.